### PR TITLE
Adding a standard for naming github repositories

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -13,7 +13,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Git
 
-1. Repo names MUST be all lowercase with hyphens (-) to separate words where appropriate.
+1. Repo names SHOULD be all lowercase with hyphens (-) to separate words where appropriate.
 
 ## PHP
 


### PR DESCRIPTION
Me and @mathieupinet were having a discussion about this on HipChat so I thought I would see what people thought about standardising the casing/naming of our repositories on GitHub.

Currently, we're in a very inconsistent state: https://github.com/graze

There's a mixture of CamelCaps, camelCase, hypenated and others. I'm not advocating renaming historial repositories but for future ones I think the standard should be lowercase with hyphens for word separation, just my personal preference.

So what do people think? Do we care about this? If not, fine. If so, what would you want the standard to be?
