### PR TITLE
Adding a standard for naming of abstract classes and interfaces

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -46,13 +46,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     // not allowed
   }
   ```
-17. Abstract class names MUST begin with `Abstract`.
+17. Abstract class names SHOULD begin with `Abstract`.
 
   ```php
   abstract class AbstractGenerator {
   }
   ```
-18. Interface names MUST end with `Interface`.
+18. Interface names SHOULD end with `Interface`.
 
   ```php
   interface GeneratorInterface {


### PR DESCRIPTION
We don't currently have a standard for naming abstract classes and interfaces, that might be fine, but I personally think we should be consistent. 

This PR is my personal preference for naming abstract classes and interfaces and we do it this way in a few places (old lib excluded).

Thoughts?
