### PR TITLE
Add standards for doc block types for scalars

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -86,7 +86,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
   - `Graze\Lib\Entity\Account\Profile\Group` -> `Graze\Lib\Repository\Account\Profile\GroupRepository`
   - `Graze\Lib\Entity\Account\Profile\GroupMap` -> `Graze\Lib\Repository\Account\Profile\GroupMapRepository`
 
-22. Valid scalar doc block types: `bool`, `int`, `string`, `float`
+22. Doc block types for scalar values MUST be one of: `bool` (not boolean), `int` (not integer), `string`, `float` (not double)
 
 ## Views
 


### PR DESCRIPTION
This is a standard we kinda have anyway but it's not written down. The standard is limited to scalar values, so `null`, `mixed`, `object` and `array` aren't included and are still valid under this standard.
