### PR TITLE
Boolean method naming standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,25 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 14. Abstract class names MUST begin with `Abstract`.
 
   ```php
-  abstract class AbstractGenerator {
+  abstract class AbstractGenerator
+  {
   }
   ```
 15. Interface names MUST end with `Interface`.
 
   ```php
-  interface GeneratorInterface {
+  interface GeneratorInterface
+  {
+  }
+  ```
+16. Methods that return a bool MUST be prefixed with either `is` or `has`.
+
+  ```php
+  interface FooInterface
+  {
+      public function isFoo();
+      
+      public function hasFoo();
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     }
     
     // better
-    public function IsAllowedToUse()
+    public function isAllowedToUse()
     {
     }
     

--- a/README.md
+++ b/README.md
@@ -65,14 +65,47 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
   {
   }
   ```
-16. Methods that return a bool MUST be prefixed with either `is` or `has`.
+16. It is RECOMMENDED that bool methods be named using [auxillary verb](https://en.wikipedia.org/wiki/Auxiliary_verb#A_list_of_auxiliaries_in_English) prefixes where appropriate.
 
   ```php
-  interface FooInterface
+  class Foo
   {
-      public function isFoo();
-      
-      public function hasFoo();
+    private $on;
+
+    // bad
+    public function getOn()
+    {
+    }
+
+    // good
+    public function isOn()
+    {
+    }
+    
+    // not great
+    public function didItWork()
+    {
+    }
+    
+    // better
+    public function hasItWorked()
+    {
+    }
+    
+    // not great
+    public function allowedToUse()
+    {
+    }
+    
+    // better
+    public function IsAllowedToUse()
+    {
+    }
+    
+    // better still
+    public function canUse()
+    {
+    }
   }
   ```
 


### PR DESCRIPTION
This is my personal preference and it makes a lot of sense to me. I like that this kind of convention enables more self-documenting code, I see `is*()` or `has*()` and I know it will return me a bool. Also makes it easier to find existing methods and not duplicate them.

The example that triggered this:

`appliedCardRefreshReward()` vs `hasAppliedCardRefreshReward()`

Please vote 👍  or 👎  using the reactions.