### PR TITLE
fix sub function return check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 build:
 	@docker run --rm -it \
-		-v $$(pwd):/usr/src/app \
-		-v ~/.composer:/home/composer/.composer \
-		-v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
-		graze/composer install
-
+		-v $$(pwd):/app \
+		-v ~/.composer:/tmp \
+		composer install
 
 lint: ## Check the validness of markdown/php
 lint: lint-md lint-php

--- a/PHP/CodeSniffer/Graze/Sniffs/Commenting/MissingFunctionCommentSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Commenting/MissingFunctionCommentSniff.php
@@ -86,7 +86,7 @@ class MissingFunctionCommentSniff implements Sniff
         $end = $tokens[$stackPtr]['scope_closer'];
 
         for ($i = $start; $i <= $end; $i++) {
-            if ($tokens[$i]['code'] === T_CLOSURE) {
+            if ($tokens[$i]['code'] === T_CLOSURE || $tokens[$i]['code'] === T_FUNCTION) {
                 // skip over closures within our function
                 $i = $tokens[$i]['scope_closer'];
             }

--- a/examples/PHP/functions.php
+++ b/examples/PHP/functions.php
@@ -61,3 +61,16 @@ $foo->bar(
     },
     $arg3
 );
+
+function first()
+{
+    /**
+     * @return bool
+     */
+    function second()
+    {
+        return true;
+    }
+
+    second();
+}

--- a/examples/PHP/functions.php
+++ b/examples/PHP/functions.php
@@ -62,6 +62,7 @@ $foo->bar(
     $arg3
 );
 
+// no doc comment required for non returning functions
 function first()
 {
     /**


### PR DESCRIPTION
Our phpcs standards fail for sub function return checking.

This should fix it.

**expected**: nothing
**old**: failure, **new**: nothing
```php
function first()
{
    /**
     * @return bool
     */
    function second()
    {
        return true;
    }

    second();
}
```

**expected**: failure
**old**: failure, **new**: failure
```php
function first()
{
    /**
     * @return bool
     */
    function second()
    {
        return true;
    }

    return second();
}
```