### PR TITLE
add new versions of php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ cache:
 php:
   - 5.5
   - 5.6
-  - 7
+  - 7.0
   - 7.1
+  - 7.2
   - hhvm
   - nightly
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build:
 	@docker run --rm -it \
-		-v $$(pwd):/app \
-		-v ~/.composer:/tmp \
+		-v $$(pwd):/app:delegated \
+		-v ~/.composer:/tmp:delegated \
 		composer install
 
 lint: ## Check the validness of markdown/php


### PR DESCRIPTION
- Adds 7.2
- use `:delegated` flag to speed up local development for mac users