### PR TITLE
PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
 - 7.0
 - 7.1
 - 7.2
-- hhvm
 - nightly
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache:
   directories:
   - "$HOME/.composer/cache/files"
 php:
-- 5.5
-- 5.6
-- 7.0
 - 7.1
 - 7.2
 - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 php:
 - 7.1
 - 7.2
+- 7.3
 - nightly
 matrix:
   fast_finish: true


### PR DESCRIPTION
Travis configuration update:
- Remove HHVM and versions that are out of support (5.5, 5.6, 7.0).
- Add 7.3.