### PR TITLE
Fix error with Abstract naming sniff

### DIFF
--- a/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php
@@ -71,7 +71,7 @@ class AbstractClassNamingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[($stackPtr - 2)]['code'] === T_ABSTRACT) {
+        if ($stackPtr > 2 && $tokens[($stackPtr - 2)]['code'] === T_ABSTRACT) {
             $className = $phpcsFile->getDeclarationName($stackPtr);
 
             if (substr($className, 0, 8) !== 'Abstract') {


### PR DESCRIPTION
The following class definition:

    <?php
    class Foo

would cause this error:

> An error occurred during processing; checking has been aborted. The error message was: Undefined offset: -1 in [...]/vendor/graze/standards/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php on line 78 (Internal.Exception)

This assumed two tokens before the "class" keyword ("<?php>" and a newline).

This commit addresses this assumption.