### PR TITLE
Add sniff for space after logical NOT

### DIFF
--- a/PHP/CodeSniffer/Graze/Sniffs/Commenting/InvalidTypeSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Commenting/InvalidTypeSniff.php
@@ -50,11 +50,11 @@ class InvalidTypeSniff implements Sniff
 
         $commentEnd = $phpcsFile->findPrevious($commentToken, $stackPtr);
 
-        if (! $commentEnd) {
+        if (!$commentEnd) {
             return;
         }
 
-        if (! array_key_exists('comment_opener', $tokens[$commentEnd])) {
+        if (!array_key_exists('comment_opener', $tokens[$commentEnd])) {
             return;
         }
 

--- a/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/NegationNoSpacesSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/NegationNoSpacesSniff.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Graze\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Implements the following rule:
+ *
+ * 'Not' logical operators MUST NOT have whitespace between them and the subject being negated.
+ */
+class NegationNoSpacesSniff implements Sniff
+{
+    const ERROR_CODE = 'graze.controlStructures.NegationNoSpaces';
+
+    /**
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            T_BOOLEAN_NOT
+        ];
+    }
+
+    /**
+     * @param File $phpcsFile The PHP_CodeSniffer file where the
+     *        token was found.
+     * @param int $stackPtr The position in the PHP_CodeSniffer
+     *        file's token stack where the token was found.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr + 1]['code'] === T_WHITESPACE) {
+            $phpcsFile->addError('Space found after logical NOT operator', $stackPtr + 1, self::ERROR_CODE);
+        }
+    }
+}

--- a/PHP/CodeSniffer/Graze/ruleset.xml
+++ b/PHP/CodeSniffer/Graze/ruleset.xml
@@ -102,6 +102,7 @@
     <rule ref="Graze.Naming.AbstractClassNaming" />
     <rule ref="Graze.Naming.InterfaceNaming" />
     <rule ref="Graze.ControlStructures.IfVariableAssignment" />
+    <rule ref="Graze.ControlStructures.NegationNoSpaces" />
     <rule ref="Graze.ControlStructures.NestedTernary" />
     <rule ref="Graze.Files.DoubleBlankLine" />
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "b9046536bcd0b35492cedaff5f12d6bd",
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.1.1",
+            "version": "3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e"
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d667e245d5dcd4d7bf80f26f2c947d476b66213e",
-                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
             "require": {
@@ -28,7 +28,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -51,12 +51,12 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-10-16T22:40:25+00:00"
+            "time": "2020-04-17T01:09:41+00:00"
         }
     ],
     "aliases": [],
@@ -65,5 +65,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Add a sniff for the following rule:

> 'Not' logical operators MUST NOT have whitespace between them and the subject being negated.