### PR TITLE
Fix sniff names that get printed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ lint-php: ## Check the validness of php
 	@echo 'linting php...'
 	@mkdir -p cache
 	@docker run --rm -it -v $$(pwd):/srv:cached graze/php-alpine:test vendor/bin/phpcs \
-		-p --warning-severity=0 --cache=cache/phpcs --parallel=10 \
+		-p --warning-severity=0 --cache=cache/phpcs --parallel=10 -s \
 		PHP/ examples/

--- a/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/IfVariableAssignmentSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/IfVariableAssignmentSniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class IfVariableAssignmentSniff implements Sniff
 {
-    const ERROR_CODE = 'graze.controlStructures.ifVariableAssignment';
+    const ERROR_CODE = 'Graze.ControlStructures.IfVariableAssignment';
     /**
      * Registers the tokens that this sniff wants to listen for.
      *

--- a/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/NegationNoSpacesSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/NegationNoSpacesSniff.php
@@ -12,7 +12,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  */
 class NegationNoSpacesSniff implements Sniff
 {
-    const ERROR_CODE = 'graze.controlStructures.NegationNoSpaces';
+    const ERROR_CODE = 'Graze.ControlStructures.NegationNoSpaces';
 
     /**
      * @return int[]

--- a/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/NestedTernarySniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/ControlStructures/NestedTernarySniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class NestedTernarySniff implements Sniff
 {
-    const ERROR_CODE = 'graze.controlStructures.nestedTernary';
+    const ERROR_CODE = 'Graze.ControlStructures.NestedTernary';
 
     /**
      * Registers the tokens that this sniff wants to listen for.

--- a/PHP/CodeSniffer/Graze/Sniffs/Files/DoubleBlankLineSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Files/DoubleBlankLineSniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class DoubleBlankLineSniff implements Sniff
 {
-    const ERROR_CODE = 'graze.files.doubleBlankLine';
+    const ERROR_CODE = 'Graze.Files.DoubleBlankLine';
 
     /**
      * Registers the tokens that this sniff wants to listen for.

--- a/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class AbstractClassNamingSniff implements Sniff
 {
-    const ERROR_CODE = 'graze.naming.abstractClass';
+    const ERROR_CODE = 'Graze.Naming.AbstractClassNaming';
 
     /**
      * Registers the tokens that this sniff wants to listen for.

--- a/PHP/CodeSniffer/Graze/Sniffs/Naming/InterfaceNamingSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Naming/InterfaceNamingSniff.php
@@ -7,7 +7,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class InterfaceNamingSniff implements Sniff
 {
-    const ERROR_CODE = 'graze.naming.interface';
+    const ERROR_CODE = 'Graze.Naming.InterfaceNaming';
 
     /**
      * Registers the tokens that this sniff wants to listen for.


### PR DESCRIPTION
Making sure that the message produced via `phpcs -s` actually matches the sniff name, for ease of working further with this.

Previously you would see this:

```
------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------
 13 | ERROR | Space found after logical NOT operator
    |       | (graze.controlStructures.NegationNoSpaces)
------------------------------------------------------------------------------------------------
```

That's not the name of the sniff and so if you try to do anything with that (eg. adding it to a ruleset) phpcs will complain that the sniff does not exist.

Now you will correctly see this instead:

```
------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------
 13 | ERROR | Space found after logical NOT operator
    |       | (Graze.ControlStructures.NegationNoSpaces)
------------------------------------------------------------------------------------------------
```