### PR TITLE
Fix error reporting for abstract naming sniff

### DIFF
--- a/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php
+++ b/PHP/CodeSniffer/Graze/Sniffs/Naming/AbstractClassNamingSniff.php
@@ -75,7 +75,7 @@ class AbstractClassNamingSniff implements Sniff
             $className = $phpcsFile->getDeclarationName($stackPtr);
 
             if (substr($className, 0, 8) !== 'Abstract') {
-                $phpcsFile->addError('Abstract class name "%s" must be prefixed with "Abstract"', $stackPtr, static::ERROR_CODE, '', [$className]);
+                $phpcsFile->addError('Abstract class name "%s" must be prefixed with "Abstract"', $stackPtr, static::ERROR_CODE, [$className]);
             }
         }
     }


### PR DESCRIPTION
Previously the error message showed a placeholder rather than the class
name, like this:

    Abstract class name "%s" must be prefixed with "Abstract"

It now shows the class name, like this:

    Abstract class name "Foo" must be prefixed with "Abstract"